### PR TITLE
Refactoring column output and export routines

### DIFF
--- a/inst/sql/sql_server/Achilles_v5.sql
+++ b/inst/sql/sql_server/Achilles_v5.sql
@@ -819,7 +819,7 @@ insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_na
 	values (620, 'Number of procedure occurrence records  by procedure occurrence start month', 'calendar month');
 
 insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name, stratum_2_name)
-	values (691, 'Percentage of total persons that have at least x procedures', 'procedure_id', 'procedure_person');
+	values (691, 'Number of persons that have at least x procedures', 'procedure_id', 'procedure_count');
 
 --700- DRUG_EXPOSURE
 
@@ -878,7 +878,7 @@ insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_na
 	values (720, 'Number of drug exposure records  by drug exposure start month', 'calendar month');
 
 insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name, stratum_2_name)
-	values (791, 'Percentage of total persons that have at least x drug exposures', 'drug_concept_id', 'drug_person');
+	values (791, 'Number of persons that have at least x drug exposures', 'drug_concept_id', 'drug_count');
 
 --800- OBSERVATION
 
@@ -929,7 +929,7 @@ insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_na
 	values (820, 'Number of observation records  by observation start month', 'calendar month');
 
 insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name, stratum_2_name)
-	values (891, 'Percentage of total persons that have at least x observations', 'observation_concept_id', 'observation_person');
+	values (891, 'Number of persons that have at least x observations', 'observation_concept_id', 'observation_count');
 
 --900- DRUG_ERA
 
@@ -1222,7 +1222,7 @@ insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_na
 	values (1821, 'Number of measurement records with no numeric value');
 
 insert into @results_database_schema.ACHILLES_analysis (analysis_id, analysis_name, stratum_1_name, stratum_2_name)
-	values (1891, 'Percentage of total persons that have at least x measurements', 'measurement_concept_id', 'measurement_person');
+	values (1891, 'Number of persons that have at least x measurements', 'measurement_concept_id', 'measurement_count');
 
 --1900 REPORTS
 
@@ -3567,28 +3567,22 @@ group by YEAR(procedure_date)*100 + month(procedure_date)
 
 
 --{691 IN (@list_of_analysis_ids)}?{
--- 691	Percentage of total persons that have at least x procedures
-create table #tempResults (p_concept_id int, proc_cnt int, person_cnt int);
-insert into #tempResults
-select procedure_concept_id, prc_cnt, sum(count(person_id))
-over (partition by procedure_concept_id order by prc_cnt desc)
-from (select p.procedure_concept_id, 
-	count(p.procedure_occurrence_id) as prc_cnt, 
-	p.person_id
-	from @cdm_database_schema.procedure_occurrence p 
-	group by p.person_id, p.procedure_concept_id) as cnt_q
-group by procedure_concept_id, prc_cnt;
-
-with person_count as (select count(*) as total_persons from @cdm_database_schema.person)
+-- 691	Number of total persons that have at least x procedures
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 691 as analysis_id,
-	p_concept_id as stratum_1, 
-	round((person_cnt * 100.0)/(total_persons * 1.0), 2) as stratum_2,
-	proc_cnt as count_value
-from #tempResults, person_count;
-
-truncate table #tempResults;
-drop table #tempResults;
+select 
+	691 as analysis_id,
+	procedure_concept_id as stratum_1, 
+	prc_cnt as stratum_2,
+	sum(count(person_id))	over (partition by procedure_concept_id order by prc_cnt desc) as count_value
+from (
+	select 
+		p.procedure_concept_id, 
+		count(p.procedure_occurrence_id) as prc_cnt, 
+		p.person_id
+	from @cdm_database_schema.procedure_occurrence p 
+	group by p.person_id, p.procedure_concept_id
+) as cnt_q
+group by procedure_concept_id, prc_cnt;
 --}
 
 /********************************************
@@ -4093,28 +4087,22 @@ group by YEAR(drug_exposure_start_date)*100 + month(drug_exposure_start_date)
 --}
 
 --{791 IN (@list_of_analysis_ids)}?{
--- 791	Percentage of total persons that have at least x drug exposures
-create table #tempResults (d_concept_id int, drug_cnt int, person_cnt int);
-insert into #tempResults
-select drug_concept_id, drg_cnt, sum(count(person_id))
-over (partition by drug_concept_id order by drg_cnt desc)
-from (select d.drug_concept_id, 
-	count(d.drug_exposure_id) as drg_cnt, 
-	d.person_id
-	from @cdm_database_schema.drug_exposure d 
-	group by d.person_id, d.drug_concept_id) as cnt_q
-group by drug_concept_id, drg_cnt;
-
-with person_count as (select count(*) as total_persons from @cdm_database_schema.person)
+-- 791	Number of total persons that have at least x drug exposures
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 791 as analysis_id,
-	d_concept_id as stratum_1, 
-	round((person_cnt * 100.0)/(total_persons * 1.0), 2) as stratum_2,
-	drug_cnt as count_value
-from #tempResults, person_count;
-
-truncate table #tempResults;
-drop table #tempResults;
+select 
+	791 as analysis_id,
+	drug_concept_id as stratum_1, 
+	drg_cnt as stratum_2,
+	sum(count(person_id))	over (partition by drug_concept_id order by drg_cnt desc) as count_value
+from (
+	select 
+		d.drug_concept_id, 
+		count(d.drug_exposure_id) as drg_cnt, 
+		d.person_id
+	from @cdm_database_schema.drug_exposure d 
+	group by d.person_id, d.drug_concept_id
+) as cnt_q
+group by drug_concept_id, drg_cnt;
 --}
 
 /********************************************
@@ -4548,28 +4536,22 @@ group by YEAR(observation_date)*100 + month(observation_date)
 
 
 --{891 IN (@list_of_analysis_ids)}?{
--- 891	Percentage of total persons that have at least x observations
-create table #tempResults (o_concept_id int, obs_cnt int, person_cnt int);
-insert into #tempResults
-select observation_concept_id, obs_cnt, sum(count(person_id))
-over (partition by observation_concept_id order by obs_cnt desc)
-from (select o.observation_concept_id, 
-	count(o.observation_id) as obs_cnt, 
-	o.person_id
-	from @cdm_database_schema.observation o 
-	group by o.person_id, o.observation_concept_id) as cnt_q
-group by observation_concept_id, obs_cnt;
-
-with person_count as (select count(*) as total_persons from @cdm_database_schema.person)
+-- 891	Number of total persons that have at least x observations
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 891 as analysis_id,
-	o_concept_id as stratum_1, 
-	round((person_cnt * 100.0)/(total_persons * 1.0), 2) as stratum_2,
-	obs_cnt as count_value
-from #tempResults, person_count;
-
-truncate table #tempResults;
-drop table #tempResults;
+select 
+	891 as analysis_id,
+	observation_concept_id as stratum_1, 
+	obs_cnt as stratum_2,
+	sum(count(person_id))	over (partition by observation_concept_id order by obs_cnt desc) as count_value
+from (
+	select 
+		o.observation_concept_id, 
+		count(o.observation_id) as obs_cnt, 
+		o.person_id
+	from @cdm_database_schema.observation o 
+	group by o.person_id, o.observation_concept_id
+) as cnt_q
+group by observation_concept_id, obs_cnt;
 --}
 
 
@@ -7530,28 +7512,22 @@ where m.value_as_number is null
 
 
 --{1891 IN (@list_of_analysis_ids)}?{
--- 1891	Percentage of total persons that have at least x measurements
-create table #tempResults (m_concept_id int, measure_cnt int, person_cnt int);
-insert into #tempResults
-select measurement_concept_id, meas_cnt, sum(count(person_id))
-over (partition by measurement_concept_id order by meas_cnt desc)
-from (select m.measurement_concept_id, 
-	count(m.measurement_id) as meas_cnt, 
-	m.person_id
-	from @cdm_database_schema.measurement m 
-	group by m.person_id, m.measurement_concept_id) as cnt_q
-group by measurement_concept_id, meas_cnt;
-
-with person_count as (select count(*) as total_persons from @cdm_database_schema.person)
+-- 1891	Number of total persons that have at least x measurements
 insert into @results_database_schema.ACHILLES_results (analysis_id, stratum_1, stratum_2, count_value)
-select 1891 as analysis_id,
-	m_concept_id as stratum_1, 
-	round((person_cnt * 100.0)/(total_persons * 1.0), 2) as stratum_2,
-	measure_cnt as count_value
-from #tempResults, person_count;
-
-truncate table #tempResults;
-drop table #tempResults;
+select 
+	1891 as analysis_id,
+	measurement_concept_id as stratum_1, 
+	meas_cnt as stratum_2,
+	sum(count(person_id))	over (partition by measurement_concept_id order by meas_cnt desc) as count_value
+from (
+	select 
+		m.measurement_concept_id, 
+		count(m.measurement_id) as meas_cnt, 
+		m.person_id
+	from @cdm_database_schema.measurement m 
+	group by m.person_id, m.measurement_concept_id
+) as cnt_q
+group by measurement_concept_id, meas_cnt;
 --}
 --end of measurment analyses
 
@@ -7783,15 +7759,7 @@ group by m.note_type_CONCEPT_ID
 
 --final processing of results
 delete from @results_database_schema.ACHILLES_results 
-where analysis_id <> 691 
-	and analysis_id <> 791 
-	and analysis_id <> 891 
-	and analysis_id <> 1891 
-	and count_value <= @smallcellcount;
+where count_value <= @smallcellcount;
 delete from @results_database_schema.ACHILLES_results_dist 
-where analysis_id <> 691 
-	and analysis_id <> 791
-	and analysis_id <> 891
-	and analysis_id <> 1891
-	and count_value <= @smallcellcount;
+where count_value <= @smallcellcount;
 

--- a/inst/sql/sql_server/export_v5/drug/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlFrequencyDistribution.sql
@@ -1,6 +1,6 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,

--- a/inst/sql/sql_server/export_v5/drug/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/drug/sqlFrequencyDistribution.sql
@@ -1,9 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	num.stratum_2 as Y_NUM_PERSONS,
-	num.count_value as X_COUNT
+	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	num.stratum_2 as X_COUNT
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as decimal) stratum_2, count_value 
+	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,
+	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
 	from @results_database_schema.ACHILLES_results 
 	where analysis_id = 791) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id

--- a/inst/sql/sql_server/export_v5/measurement/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlFrequencyDistribution.sql
@@ -1,6 +1,6 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,

--- a/inst/sql/sql_server/export_v5/measurement/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/measurement/sqlFrequencyDistribution.sql
@@ -1,11 +1,11 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	num.stratum_2 as Y_NUM_PERSONS,
-	num.count_value as X_COUNT  
+	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	num.stratum_2 as X_COUNT
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as decimal) stratum_2, count_value 
+	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,
+	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
 	from @results_database_schema.ACHILLES_results 
 	where analysis_id = 1891) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 	order by num.stratum_2
-	

--- a/inst/sql/sql_server/export_v5/observation/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlFrequencyDistribution.sql
@@ -1,6 +1,6 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,

--- a/inst/sql/sql_server/export_v5/observation/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/observation/sqlFrequencyDistribution.sql
@@ -1,11 +1,11 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	num.stratum_2 as Y_NUM_PERSONS,
-	num.count_value as X_COUNT
+	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	num.stratum_2 as X_COUNT
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as decimal) stratum_2, count_value 
+	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,
+	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
 	from @results_database_schema.ACHILLES_results 
 	where analysis_id = 891) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id
 	order by num.stratum_2
-	

--- a/inst/sql/sql_server/export_v5/procedure/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlFrequencyDistribution.sql
@@ -1,6 +1,6 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	cast(round((100.0*num.count_value / denom.count_value), 0) as int) as Y_NUM_PERSONS,
 	num.stratum_2 as X_COUNT
 from 
 	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,

--- a/inst/sql/sql_server/export_v5/procedure/sqlFrequencyDistribution.sql
+++ b/inst/sql/sql_server/export_v5/procedure/sqlFrequencyDistribution.sql
@@ -1,9 +1,10 @@
 select c1.concept_id as CONCEPT_ID, 
 	c1.concept_name as CONCEPT_NAME,
-	num.stratum_2 as Y_NUM_PERSONS,
-	num.count_value as X_COUNT
+	1.0*num.count_value / denom.count_value as Y_NUM_PERSONS,
+	num.stratum_2 as X_COUNT
 from 
-	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as decimal) stratum_2, count_value 
+	(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom,
+	(select CAST(stratum_1 as int) stratum_1, CAST(stratum_2 as int) stratum_2, count_value 
 	from @results_database_schema.ACHILLES_results 
 	where analysis_id = 691) num
 	inner join @vocab_database_schema.concept c1 on num.stratum_1 = c1.concept_id


### PR DESCRIPTION
@lhalvors @PRijnbeek I reviewed these changes and ran the code against our internal SQL PDW environment and ran into some issues. A first problem was that SQL PDW doesn't support INSERT statements that include common table expressions. As I got deeper into the review, I noted that you are storing data as:

Achilles_results.stratum_1 ==> concept_id
Achilles_results.stratum_2 ==> % people 
Achilles_results.count_value ==> the frequency # for the concept_id in a person's history 

As a result, you also had to modify the delete statement that removes any records based on the @smallcellcount setting:

```
delete from @results_database_schema.ACHILLES_results 
 where analysis_id <> 691 
 	and analysis_id <> 791 
 	and analysis_id <> 891 
 	and analysis_id <> 1891 
 	and count_value <= @smallcellcount;
delete from @results_database_schema.ACHILLES_results_dist 
 where analysis_id <> 691 
 	and analysis_id <> 791
 	and analysis_id <> 891
 	and analysis_id <> 1891
 	and count_value <= @smallcellcount;

```
In speaking with @chrisknoll, we noted that the Achilles_results.count_value should hold the count of persons as this is the convention that is used in the other analyses. As a result, I've refactored the frequency analyses to store the data as follows:

Achilles_results.stratum_1 ==> concept_id
Achilles_results.stratum_2 ==> the frequency # for the concept_id in a person's history 
Achilles_results.count_value ==> the count of persons

I then revised the delete statements referenced above to remove your analyses from the list since we want to ensure that any analyses that have a person count <= @smallcellcount are censored properly. 

Furthermore, I refactored the exportJSON SQL calls so that we calculate the % of persons and preserved the columns that you originally had in your query. The notable difference is that I've included a reference to another Achilles analysis to find the denominator when calculating the % which is consistent with the other export SQL scripts. Specifically, you will see this in the queries:

`(select count_value from @results_database_schema.ACHILLES_results where analysis_id = 1) denom`

Which references an analysis that computes the total # of people in the CDM.

I'd kindly ask you to review and test these changes. I know they will have a ripple effect to your changes for WebAPI/Atlas so I'm happy to help change that code as well. Please reach out with any questions and happy to discuss as needed. If and when you are comfortable with these changes, we can then push this update to the open pull request on the OHDSI repository.
